### PR TITLE
Patch 1.0.2

### DIFF
--- a/src/PHP.php
+++ b/src/PHP.php
@@ -106,7 +106,7 @@ class PHP {
 	 */
 	public static function simpUtilsVersion(): Version|string {
 		$class = static::redef(Version::class);
-		return new $class('1.0.1', 'SimpUtils');
+		return new $class('1.0.2', 'SimpUtils');
 	}
 
 	/**


### PR DESCRIPTION
Fixed small aspects of work with timezone of DateTime object.

Now "tz" is not read-only anymore, and it can accept string representation of Time Zone.

`setTimezone()` as well is chainable.
```php
$t = ts('previous monday 23:00', true)
   	->setTimezone('America/Los_Angeles');
```