### PR TITLE
Fixed issue with `DatePeriod` failing against changes in PHP Release 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ SOFTWARE.
    ```
    That will use native PHP mechanics for serialization, which should work properly
    starting from this release (1.1.3)
-2. Starting from the release 1.1.6 fixed the bug with timezones indirect params (this
-   partially changes the logic, but initial logic before that release was broken).
+
+[//]: # (2. Starting from the release 1.2.0 fixed the bug with timezones indirect params &#40;this)
+[//]: # (   partially changes the logic, but initial logic before that release was broken&#41;.)
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ so documentation will come after that in the very nearest time. My apologies.
 
 Minimal PHP version: **8.0**
 
-Current framework version: **1.1.5**
+Current framework version: **1.1.6**
 
 ```shell
 composer require spaf/simputils "^1"

--- a/src/PHP.php
+++ b/src/PHP.php
@@ -121,7 +121,7 @@ class PHP {
 	 */
 	public static function simpUtilsVersion(): Version|string {
 		$class = static::redef(Version::class);
-		return new $class('1.1.5', 'SimpUtils');
+		return new $class('1.1.6', 'SimpUtils');
 	}
 
 	/**

--- a/tests/general/bugs/BugTicket170.php
+++ b/tests/general/bugs/BugTicket170.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace general\bugs;
+
+use PHPUnit\Framework\TestCase;
+use function spaf\simputils\basic\ts;
+
+/**
+ * @covers DatePeriod
+ */
+class BugTicket170 extends TestCase {
+
+	function testMain() {
+		$point = "2023-11-17 17:00:00";
+		$ts = ts($point);
+		$period = $ts->period("-24 hours");
+
+		$this->assertEquals("2023-11-16 17:00:00", $period->start);
+		$this->assertEquals($point, $period->end);
+
+		$this->assertEquals("2023-11-16 17:00:00 - {$ts}", "{$period}");
+	}
+
+}


### PR DESCRIPTION
Fix for the ticket #170 